### PR TITLE
Allow to install the client from sources on Github

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -800,6 +800,7 @@
             "version": "7.4.4",
             "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
             "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
+            "dev": true,
             "requires": {
                 "core-js": "^2.6.5",
                 "regenerator-runtime": "^0.13.2"
@@ -1291,20 +1292,21 @@
             "dev": true
         },
         "asn1.js": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.0.0",
                 "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
             },
             "dependencies": {
                 "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
                     "dev": true
                 }
             }
@@ -1358,7 +1360,8 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
             "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "atob": {
             "version": "2.1.2",
@@ -1458,9 +1461,9 @@
             }
         },
         "base64-js": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true
         },
         "base64id": {
@@ -1481,16 +1484,6 @@
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
         },
-        "bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "bluebird": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -1498,9 +1491,9 @@
             "dev": true
         },
         "bn.js": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
-            "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+            "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
             "dev": true
         },
         "body-parser": {
@@ -1592,37 +1585,30 @@
             }
         },
         "browserify-rsa": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+            "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
+                "bn.js": "^5.0.0",
                 "randombytes": "^2.0.1"
-            },
-            "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                }
             }
         },
         "browserify-sign": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.1.0.tgz",
-            "integrity": "sha512-VYxo7cDCeYUoBZ0ZCy4UyEUCP3smyBd4DRQM5nrFS1jJjPJjX7rP3oLRpPoWfkhQfyJ0I9ZbHbKafrFD/SGlrg==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+            "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
             "dev": true,
             "requires": {
                 "bn.js": "^5.1.1",
                 "browserify-rsa": "^4.0.1",
                 "create-hash": "^1.2.0",
                 "create-hmac": "^1.1.7",
-                "elliptic": "^6.5.2",
+                "elliptic": "^6.5.3",
                 "inherits": "^2.0.4",
                 "parse-asn1": "^5.1.5",
-                "readable-stream": "^3.6.0"
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
             },
             "dependencies": {
                 "readable-stream": {
@@ -1635,6 +1621,12 @@
                         "string_decoder": "^1.1.1",
                         "util-deprecate": "^1.0.1"
                     }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                    "dev": true
                 }
             }
         },
@@ -1689,20 +1681,12 @@
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4",
                 "isarray": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
-                }
             }
         },
         "buffer-from": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
         },
         "buffer-xor": {
@@ -1746,25 +1730,10 @@
                 "y18n": "^4.0.0"
             },
             "dependencies": {
-                "lru-cache": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^3.0.2"
-                    }
-                },
                 "y18n": {
                     "version": "4.0.3",
                     "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
                     "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-                    "dev": true
-                },
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
                     "dev": true
                 }
             }
@@ -1874,13 +1843,10 @@
             "dev": true
         },
         "chrome-trace-event": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-            "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.9.0"
-            }
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+            "dev": true
         },
         "cipher-base": {
             "version": "1.0.4",
@@ -2121,7 +2087,8 @@
         "core-js": {
             "version": "2.6.11",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-            "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+            "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+            "dev": true
         },
         "core-js-compat": {
             "version": "3.6.5",
@@ -2158,19 +2125,19 @@
             }
         },
         "create-ecdh": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-            "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+            "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
-                "elliptic": "^6.0.0"
+                "elliptic": "^6.5.3"
             },
             "dependencies": {
                 "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
                     "dev": true
                 }
             }
@@ -2395,9 +2362,9 @@
             },
             "dependencies": {
                 "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
                     "dev": true
                 }
             }
@@ -2539,9 +2506,9 @@
             "dev": true
         },
         "enhanced-resolve": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
-            "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+            "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -2785,9 +2752,9 @@
             "dev": true
         },
         "events": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-            "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "dev": true
         },
         "evp_bytestokey": {
@@ -3012,13 +2979,6 @@
             "requires": {
                 "flat-cache": "^2.0.1"
             }
-        },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
-            "optional": true
         },
         "fill-range": {
             "version": "7.0.1",
@@ -3420,9 +3380,9 @@
                     }
                 },
                 "safe-buffer": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-                    "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
                     "dev": true
                 }
             }
@@ -3502,18 +3462,10 @@
                 "safer-buffer": ">= 2.1.2 < 3"
             }
         },
-        "idempotent-babel-polyfill": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/idempotent-babel-polyfill/-/idempotent-babel-polyfill-7.4.4.tgz",
-            "integrity": "sha512-ULnqegUJke43XlsW5bI2zvoOCiFwn5AjRK/DJA5V6jj4yf+vKEZmiYll2x9+FQb9e6a+KQ/D+r8w7ydCYuiaRA==",
-            "requires": {
-                "@babel/polyfill": "7.4.4"
-            }
-        },
         "ieee754": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "dev": true
         },
         "iferr": {
@@ -3825,6 +3777,12 @@
             "requires": {
                 "is-docker": "^2.0.0"
             }
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
         },
         "isbinaryfile": {
             "version": "4.0.10",
@@ -4355,6 +4313,15 @@
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
         },
+        "lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "requires": {
+                "yallist": "^3.0.2"
+            }
+        },
         "make-dir": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -4557,9 +4524,9 @@
             },
             "dependencies": {
                 "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
                     "dev": true
                 }
             }
@@ -4820,13 +4787,6 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
             "dev": true
-        },
-        "nan": {
-            "version": "2.14.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-            "dev": true,
-            "optional": true
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -5145,14 +5105,13 @@
             }
         },
         "parse-asn1": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-            "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+            "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
             "dev": true,
             "requires": {
-                "asn1.js": "^4.0.0",
+                "asn1.js": "^5.2.0",
                 "browserify-aes": "^1.0.0",
-                "create-hash": "^1.1.0",
                 "evp_bytestokey": "^1.0.0",
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
@@ -5186,7 +5145,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
             "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "path-exists": {
             "version": "3.0.0",
@@ -5225,9 +5185,9 @@
             "dev": true
         },
         "pbkdf2": {
-            "version": "3.0.17",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-            "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+            "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
             "dev": true,
             "requires": {
                 "create-hash": "^1.1.2",
@@ -5381,9 +5341,9 @@
             },
             "dependencies": {
                 "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
                     "dev": true
                 }
             }
@@ -5550,7 +5510,8 @@
         "regenerator-runtime": {
             "version": "0.13.5",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-            "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+            "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+            "dev": true
         },
         "regenerator-transform": {
             "version": "0.14.4",
@@ -5609,7 +5570,7 @@
             "dependencies": {
                 "jsesc": {
                     "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
                     "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
                     "dev": true
                 }
@@ -5619,7 +5580,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "repeat-element": {
             "version": "1.1.3",
@@ -5815,10 +5777,13 @@
             "dev": true
         },
         "serialize-javascript": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-            "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-            "dev": true
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -6150,9 +6115,9 @@
             }
         },
         "source-map-support": {
-            "version": "0.5.19",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-            "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -6429,9 +6394,9 @@
             "dev": true
         },
         "terser": {
-            "version": "4.6.13",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
-            "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+            "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
             "dev": true,
             "requires": {
                 "commander": "^2.20.0",
@@ -6448,16 +6413,16 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-            "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+            "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
             "dev": true,
             "requires": {
                 "cacache": "^12.0.2",
                 "find-cache-dir": "^2.1.0",
                 "is-wsl": "^1.1.0",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^2.1.2",
+                "serialize-javascript": "^4.0.0",
                 "source-map": "^0.6.1",
                 "terser": "^4.1.2",
                 "webpack-sources": "^1.4.0",
@@ -6512,9 +6477,9 @@
             }
         },
         "timers-browserify": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-            "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+            "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
             "dev": true,
             "requires": {
                 "setimmediate": "^1.0.4"
@@ -6763,7 +6728,8 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
             "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "uri-js": {
             "version": "4.2.2",
@@ -6864,14 +6830,25 @@
             "dev": true
         },
         "watchpack": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
-            "integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+            "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
             "dev": true,
             "requires": {
-                "chokidar": "^2.1.8",
+                "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0"
+                "neo-async": "^2.5.0",
+                "watchpack-chokidar2": "^2.0.1"
+            }
+        },
+        "watchpack-chokidar2": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+            "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "chokidar": "^2.1.8"
             },
             "dependencies": {
                 "anymatch": {
@@ -6879,6 +6856,7 @@
                     "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "micromatch": "^3.1.4",
                         "normalize-path": "^2.1.1"
@@ -6889,6 +6867,7 @@
                             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
                             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "remove-trailing-separator": "^1.0.1"
                             }
@@ -6899,13 +6878,15 @@
                     "version": "1.13.1",
                     "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
                     "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "braces": {
                     "version": "2.3.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "arr-flatten": "^1.1.0",
                         "array-unique": "^0.3.2",
@@ -6924,6 +6905,7 @@
                     "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
                     "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "anymatch": "^2.0.0",
                         "async-each": "^1.0.1",
@@ -6944,6 +6926,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -6953,6 +6936,7 @@
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-number": "^3.0.0",
@@ -6965,17 +6949,14 @@
                     "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "bindings": "^1.5.0",
-                        "nan": "^2.12.1"
-                    }
+                    "optional": true
                 },
                 "glob-parent": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "is-glob": "^3.1.0",
                         "path-dirname": "^1.0.0"
@@ -6986,6 +6967,7 @@
                             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "is-extglob": "^2.1.0"
                             }
@@ -6997,6 +6979,7 @@
                     "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                     "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "binary-extensions": "^1.0.0"
                     }
@@ -7005,13 +6988,15 @@
                     "version": "1.1.6",
                     "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
                     "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "is-number": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     }
@@ -7021,6 +7006,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -7030,6 +7016,7 @@
                     "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
                     "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "graceful-fs": "^4.1.11",
                         "micromatch": "^3.1.10",
@@ -7041,6 +7028,7 @@
                     "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
                     "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "is-number": "^3.0.0",
                         "repeat-string": "^1.6.1"
@@ -7049,9 +7037,9 @@
             }
         },
         "webpack": {
-            "version": "4.43.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
-            "integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
+            "version": "4.46.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz",
+            "integrity": "sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==",
             "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.9.0",
@@ -7062,7 +7050,7 @@
                 "ajv": "^6.10.2",
                 "ajv-keywords": "^3.4.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^4.1.0",
+                "enhanced-resolve": "^4.5.0",
                 "eslint-scope": "^4.0.3",
                 "json-parse-better-errors": "^1.0.2",
                 "loader-runner": "^2.4.0",
@@ -7075,7 +7063,7 @@
                 "schema-utils": "^1.0.0",
                 "tapable": "^1.1.3",
                 "terser-webpack-plugin": "^1.4.3",
-                "watchpack": "^1.6.1",
+                "watchpack": "^1.7.4",
                 "webpack-sources": "^1.4.1"
             },
             "dependencies": {
@@ -7409,6 +7397,12 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true
+        },
+        "yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -9,18 +9,21 @@
         "url": "https://github.com/cytomine/Cytomine-js-client.git"
     },
     "scripts": {
-        "dev": "webpack --mode=development --watch --info-verbosity verbose",
-        "build": "webpack --mode=production",
+        "dev": "webpack-cli --mode=development --watch --info-verbosity verbose",
+        "build": "webpack-cli --mode=production",
         "test": "./node_modules/karma/bin/karma start",
-        "prepack": "npm run build"
+        "prepack": "npm run build",
+        "prepare": "npm run build"
     },
     "files": [
         "dist",
         "src"
     ],
+    "main": "./src/index.js",
     "author": "Burtin Elodie <elodie.burtin@cytomine.coop>",
     "contributors": [
-        "Hoyoux Renaud <renaud.hoyoux@cytomine.coop"
+        "Hoyoux Renaud <renaud.hoyoux@cytomine.coop>",
+        "Rubens Ulysse <urubens@uliege.be>"
     ],
     "license": "Apache-2.0",
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "license": "Apache-2.0",
     "dependencies": {
         "axios": "^0.21.1",
-        "detect-browser": "^4.4.0",
-        "idempotent-babel-polyfill": "^7.0.0"
+        "detect-browser": "^4.4.0"
     },
     "devDependencies": {
         "@babel/core": "^7.4.3",
+        "@babel/polyfill": "^7.4.3",
         "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
         "@babel/preset-env": "^7.4.3",
         "babel-loader": "^8.0.5",
@@ -41,13 +41,13 @@
         "karma-chai": "^0.1.0",
         "karma-chai-as-promised": "0.1.2",
         "karma-firefox-launcher": "^1.1.0",
+        "karma-junit-reporter": "^2.0.1",
         "karma-mocha": "^2.0.0",
         "karma-mocha-reporter": "^2.2.5",
-        "karma-junit-reporter": "2.0.1",
-        "karma-webpack": "^4.0.0-rc.6",
+        "karma-webpack": "^4.0.2",
         "mocha": "^6.1.4",
         "randomstring": "^1.1.5",
-        "webpack": "^4.30.0",
+        "webpack": "^4.46.0",
         "webpack-cli": "^3.3.0"
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var config = {
   mode: 'development',
-  entry: ['idempotent-babel-polyfill', './src/index.js'],
+  entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'cytomine-client.js',


### PR DESCRIPTION
This PR adds the ability to install this Cytomine JS Client in a dependent repository directly from source. This library can then be installed with 
```
npm install cytomine/Cytomine-js-client#branchName --save
```

It is particularly useful during development of the webUI.