### PR TITLE
Parametrizable thumbnail/crop URLs

### DIFF
--- a/src/models/abstract-image.js
+++ b/src/models/abstract-image.js
@@ -56,7 +56,7 @@ export default class AbstractImage extends Model {
     if (this.preview === null) {
       return null;
     }
-    let url = this.preview.split('.')[0];
+    let url = this.preview.split('?')[0].split('.').slice(0,-1).join('.');
     let parameters = {maxSize, ...otherParameters};
     let query = new URLSearchParams(parameters).toString();
     return `${url}.${format}?${query}`;
@@ -74,7 +74,7 @@ export default class AbstractImage extends Model {
     if (this.thumb === null) {
       return null;
     }
-    let url = this.thumb.split('.')[0];
+    let url = this.thumb.split('?')[0].split('.').slice(0,-1).join('.');
     let parameters = {maxSize, ...otherParameters};
     let query = new URLSearchParams(parameters).toString();
     return `${url}.${format}?${query}`;
@@ -93,7 +93,7 @@ export default class AbstractImage extends Model {
     if (this.macroURL === null) {
       return null;
     }
-    let url = this.macroURL.split('.')[0];
+    let url = this.macroURL.split('?')[0].split('.').slice(0,-1).join('.');
     url = url.substr(0, url.lastIndexOf('/'));
     let parameters = {maxSize, ...otherParameters};
     let query = new URLSearchParams(parameters).toString();

--- a/src/models/abstract-image.js
+++ b/src/models/abstract-image.js
@@ -94,7 +94,7 @@ export default class AbstractImage extends Model {
       return null;
     }
     let url = this.macroURL.split('?')[0].split('.').slice(0,-1).join('.');
-    url = url.substr(0, url.lastIndexOf('/'));
+    url = url.substring(0, url.lastIndexOf('/'));
     let parameters = {maxSize, ...otherParameters};
     let query = new URLSearchParams(parameters).toString();
     return `${url}/${kind}.${format}?${query}`;

--- a/src/models/abstract-image.js
+++ b/src/models/abstract-image.js
@@ -45,10 +45,59 @@ export default class AbstractImage extends Model {
   }
 
   /**
-  * @returns {String} the preview URL of the image with a specified size
-  */
-  previewURL(size) {
-    return this.preview.replace(/maxSize=\d+/, 'maxSize='+size);
+   * Get the preview URL.
+   *
+   * @param maxSize the desired preview size along largest side
+   * @param format the desired preview format (jpg, png, webp)
+   * @param otherParameters optional other parameters to include in the preview URL
+   * @returns {String} the preview URL of the image with a specified size
+   */
+  previewURL(maxSize = 256, format = 'jpg', otherParameters = {}) {
+    if (this.preview === null) {
+      return null;
+    }
+    let url = this.preview.split('.')[0];
+    let parameters = {maxSize, ...otherParameters};
+    let query = new URLSearchParams(parameters).toString();
+    return `${url}.${format}?${query}`;
+  }
+
+  /**
+   * Get the thumbnail URL.
+   *
+   * @param maxSize the desired thumb size along largest side
+   * @param format the desired thumb format (jpg, png, webp)
+   * @param otherParameters optional other parameters to include in the thumb URL
+   * @returns {String} the thumb URL of the image with a specified size
+   */
+  thumbURL(maxSize = 256, format = 'jpg', otherParameters = {}) {
+    if (this.thumb === null) {
+      return null;
+    }
+    let url = this.thumb.split('.')[0];
+    let parameters = {maxSize, ...otherParameters};
+    let query = new URLSearchParams(parameters).toString();
+    return `${url}.${format}?${query}`;
+  }
+
+  /**
+   * Get the associated image URL.
+   *
+   * @param kind the associated type (macro, label)
+   * @param maxSize the desired associated image size along largest side
+   * @param format the desired associated image format (jpg, png, webp)
+   * @param otherParameters optional other parameters to include in the associated image URL
+   * @returns {String} the associated image URL of the image with a specified size
+   */
+  associatedImageURL(kind = 'macro', maxSize = 256, format = 'jpg', otherParameters = {}) {
+    if (this.macroURL === null) {
+      return null;
+    }
+    let url = this.macroURL.split('.')[0];
+    url = url.substr(0, url.lastIndexOf('/'));
+    let parameters = {maxSize, ...otherParameters};
+    let query = new URLSearchParams(parameters).toString();
+    return `${url}/${kind}.${format}?${query}`;
   }
 
   /**

--- a/src/models/annotation.js
+++ b/src/models/annotation.js
@@ -73,6 +73,24 @@ export default class Annotation extends Model {
   }
 
   /**
+   * Get the annotation crop URL.
+   *
+   * @param maxSize the desired crop size along largest side
+   * @param format the desired crop format (jpg, png, webp)
+   * @param otherParameters optional other parameters to include in the crop URL
+   * @returns {String} the crop URL of the annotation with a specified size
+   */
+  annotationCropURL(maxSize = 256, format = 'jpg', otherParameters = {}) {
+    if (this.cropURL === null) {
+      return null;
+    }
+    let url = this.cropURL.split('.')[0];
+    let parameters = {maxSize, ...otherParameters};
+    let query = new URLSearchParams(parameters).toString();
+    return `${url}.${format}?${query}`;
+  }
+
+  /**
    * @override
    * @static Fetch an annotation
    *

--- a/src/models/annotation.js
+++ b/src/models/annotation.js
@@ -84,7 +84,7 @@ export default class Annotation extends Model {
     if (this.cropURL === null) {
       return null;
     }
-    let url = this.cropURL.split('.')[0];
+    let url = this.cropURL.split('?')[0].split('.').slice(0,-1).join('.');
     let parameters = {maxSize, ...otherParameters};
     let query = new URLSearchParams(parameters).toString();
     return `${url}.${format}?${query}`;

--- a/src/models/image-instance.js
+++ b/src/models/image-instance.js
@@ -69,7 +69,7 @@ export default class ImageInstance extends Model {
     if (this.preview === null) {
       return null;
     }
-    let url = this.preview.split('.')[0];
+    let url = this.preview.split('?')[0].split('.').slice(0,-1).join('.');
     let parameters = {maxSize, ...otherParameters};
     let query = new URLSearchParams(parameters).toString();
     return `${url}.${format}?${query}`;
@@ -87,7 +87,7 @@ export default class ImageInstance extends Model {
     if (this.thumb === null) {
       return null;
     }
-    let url = this.thumb.split('.')[0];
+    let url = this.thumb.split('?')[0].split('.').slice(0,-1).join('.');
     let parameters = {maxSize, ...otherParameters};
     let query = new URLSearchParams(parameters).toString();
     return `${url}.${format}?${query}`;
@@ -106,7 +106,7 @@ export default class ImageInstance extends Model {
     if (this.macroURL === null) {
       return null;
     }
-    let url = this.macroURL.split('.')[0];
+    let url = this.macroURL.split('?')[0].split('.').slice(0,-1).join('.');
     url = url.substr(0, url.lastIndexOf('/'));
     let parameters = {maxSize, ...otherParameters};
     let query = new URLSearchParams(parameters).toString();

--- a/src/models/image-instance.js
+++ b/src/models/image-instance.js
@@ -39,7 +39,7 @@ export default class ImageInstance extends Model {
 
     this.thumb = null;
     this.preview = null;
-    this.macro = null;
+    this.macroURL = null;
 
     this.numberOfAnnotations = null;
     this.numberOfJobAnnotations = null;
@@ -58,17 +58,59 @@ export default class ImageInstance extends Model {
   }
 
   /**
-  * @returns {String} the preview URL of the image with a specified size
-  */
-  previewURL(size) {
-    return this.preview.replace(/maxSize=\d+/, 'maxSize='+size);
+   * Get the preview URL.
+   *
+   * @param maxSize the desired preview size along largest side
+   * @param format the desired preview format (jpg, png, webp)
+   * @param otherParameters optional other parameters to include in the preview URL
+   * @returns {String} the preview URL of the image with a specified size
+   */
+  previewURL(maxSize = 256, format = 'jpg', otherParameters = {}) {
+    if (this.preview === null) {
+      return null;
+    }
+    let url = this.preview.split('.')[0];
+    let parameters = {maxSize, ...otherParameters};
+    let query = new URLSearchParams(parameters).toString();
+    return `${url}.${format}?${query}`;
   }
 
   /**
-  * @returns {String} the thumb URL of the image with a specified size
-  */
-  thumbURL(size) {
-    return this.thumb.replace(/maxSize=\d+/, 'maxSize='+size);
+   * Get the thumbnail URL.
+   *
+   * @param maxSize the desired thumb size along largest side
+   * @param format the desired thumb format (jpg, png, webp)
+   * @param otherParameters optional other parameters to include in the thumb URL
+   * @returns {String} the thumb URL of the image with a specified size
+   */
+  thumbURL(maxSize = 256, format = 'jpg', otherParameters = {}) {
+    if (this.thumb === null) {
+      return null;
+    }
+    let url = this.thumb.split('.')[0];
+    let parameters = {maxSize, ...otherParameters};
+    let query = new URLSearchParams(parameters).toString();
+    return `${url}.${format}?${query}`;
+  }
+
+  /**
+   * Get the associated image URL.
+   *
+   * @param kind the associated type (macro, label)
+   * @param maxSize the desired associated image size along largest side
+   * @param format the desired associated image format (jpg, png, webp)
+   * @param otherParameters optional other parameters to include in the associated image URL
+   * @returns {String} the associated image URL of the image with a specified size
+   */
+  associatedImageURL(kind = 'macro', maxSize = 256, format = 'jpg', otherParameters = {}) {
+    if (this.macroURL === null) {
+      return null;
+    }
+    let url = this.macroURL.split('.')[0];
+    url = url.substr(0, url.lastIndexOf('/'));
+    let parameters = {maxSize, ...otherParameters};
+    let query = new URLSearchParams(parameters).toString();
+    return `${url}/${kind}.${format}?${query}`;
   }
 
   /**

--- a/src/models/image-instance.js
+++ b/src/models/image-instance.js
@@ -107,7 +107,7 @@ export default class ImageInstance extends Model {
       return null;
     }
     let url = this.macroURL.split('?')[0].split('.').slice(0,-1).join('.');
-    url = url.substr(0, url.lastIndexOf('/'));
+    url = url.substring(0, url.lastIndexOf('/'));
     let parameters = {maxSize, ...otherParameters};
     let query = new URLSearchParams(parameters).toString();
     return `${url}/${kind}.${format}?${query}`;


### PR DESCRIPTION
With this PR, the thumbnail/preview/macro/crop URL of a an ImageInstance, an AbstractImage or an annotation can be parametrized with size, expected response image format and optional other parameters.

It has been implemented & tested with PIMS in mind but as these URLs are parts of the Cytomine-Core API that has not changed, it should be completely backward compatible with IMS.