### PR TITLE
Fix polyfill & "`regeneratorRuntime` is not defined" error

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,7 +17,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'node_modules/@babel/polyfill/dist/polyfill.js',
+      'src/index.js',
       'tests/test-*.js'
     ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -796,16 +796,6 @@
                 "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
-        "@babel/polyfill": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-            "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
-            "dev": true,
-            "requires": {
-                "core-js": "^2.6.5",
-                "regenerator-runtime": "^0.13.2"
-            }
-        },
         "@babel/preset-env": {
             "version": "7.9.6",
             "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.6.tgz",
@@ -1484,6 +1474,16 @@
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "bluebird": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -1794,7 +1794,7 @@
         "chai-as-promised": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
-            "integrity": "sha1-CdekApCKpw39vq1T5YU/x50+8hw=",
+            "integrity": "sha512-pgAOHklxHtjFAU+SXt8aDJt/OQxR4om8ZSJXQT6nObuxwGEVZ69VZR0JZzj4mDLo6OHKCO6uLTmAhPyuHJw0rw==",
             "dev": true
         },
         "chalk": {
@@ -2085,10 +2085,9 @@
             "dev": true
         },
         "core-js": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-            "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-            "dev": true
+            "version": "3.22.5",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.5.tgz",
+            "integrity": "sha512-VP/xYuvJ0MJWRAobcmQ8F2H6Bsn+s7zqAAjFaHGBMc5AQm7zaelhD1LGduFn2EehEcQcU+br6t+fwbpQ5d1ZWA=="
         },
         "core-js-compat": {
             "version": "3.6.5",
@@ -2979,6 +2978,13 @@
             "requires": {
                 "flat-cache": "^2.0.1"
             }
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "optional": true
         },
         "fill-range": {
             "version": "7.0.1",
@@ -4788,6 +4794,13 @@
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
             "dev": true
         },
+        "nan": {
+            "version": "2.15.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+            "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+            "dev": true,
+            "optional": true
+        },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -5508,10 +5521,9 @@
             }
         },
         "regenerator-runtime": {
-            "version": "0.13.5",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-            "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-            "dev": true
+            "version": "0.13.9",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+            "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         },
         "regenerator-transform": {
             "version": "0.14.4",
@@ -6949,7 +6961,11 @@
                     "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
+                    }
                 },
                 "glob-parent": {
                     "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,12 @@
     "license": "Apache-2.0",
     "dependencies": {
         "axios": "^0.21.1",
-        "detect-browser": "^4.4.0"
+        "core-js": "^3.22.5",
+        "detect-browser": "^4.4.0",
+        "regenerator-runtime": "^0.13.9"
     },
     "devDependencies": {
         "@babel/core": "^7.4.3",
-        "@babel/polyfill": "^7.4.3",
         "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
         "@babel/preset-env": "^7.4.3",
         "babel-loader": "^8.0.5",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+// https://stackoverflow.com/a/54490329
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 export {default as Cytomine} from './cytomine.js';
 
 export {default as AbstractImage} from './models/abstract-image.js';

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,6 +1,6 @@
 export default {
-    host: 'localhost-core',
-    basePath: 'api/',
-    username: 'admin', // The user must be admin
-    password: 'c6a0aef9-ce9c-48c1-aacd-d09ed142cd3e'
+  host: 'localhost-core',
+  basePath: 'api/',
+  username: 'admin', // The user must be admin
+  password: 'c6a0aef9-ce9c-48c1-aacd-d09ed142cd3e'
 };


### PR DESCRIPTION
`@babel/polyfill` is deprecated and installing the Cytomine JS client in a clean environment can fail. 

I don't know exactly why (JS, NodeJS, polyfill & co are black magic to me) but using the solution proposed at https://stackoverflow.com/questions/53558916/babel-7-referenceerror-regeneratorruntime-is-not-defined solved the issue 